### PR TITLE
Delete state offsets

### DIFF
--- a/chapter5/controller.py
+++ b/chapter5/controller.py
@@ -119,7 +119,7 @@ class MonteCarloController(DiscreteController):
                 idx = state + (action,)
                 self.C[idx] += W
                 self.Q[idx] += (G - self.Q[idx]) * (W / self.C[idx])
-                W *= float(target_policy[idx[:-1]] == a) / b_policy[idx]
+                W *= float(target_policy[idx[:-1]] == action) / b_policy[idx]
                 if W == 0.0:
                     break
 

--- a/chapter5/main.py
+++ b/chapter5/main.py
@@ -224,6 +224,6 @@ def figure_5_4(figsize=(12, 12)):
 
 if __name__ == "__main__":
     figure_5_1()
-    # figure_5_2()
-    # figure_5_3()
-    # figure_5_4()
+    figure_5_2()
+    figure_5_3()
+    figure_5_4()

--- a/chapter5/main.py
+++ b/chapter5/main.py
@@ -49,7 +49,7 @@ def plot_policy(policy, ax=None, title="Policy"):
 def figure_5_1(figsize=(12, 12)):
     fig = plt.figure(figsize=figsize)
     env = BlackJack()
-    policy = lambda state: state[0] < 20
+    policy = lambda state: state[0] < 20 - env._min_sum
     for i, it in enumerate([10_000, 500_000]):
         mc = MonteCarloPredictor(env)
         mc.predict(policy, alpha=1.0, n_episodes=it)
@@ -224,6 +224,6 @@ def figure_5_4(figsize=(12, 12)):
 
 if __name__ == "__main__":
     figure_5_1()
-    figure_5_2()
-    figure_5_3()
-    figure_5_4()
+    # figure_5_2()
+    # figure_5_3()
+    # figure_5_4()

--- a/chapter5/predictor.py
+++ b/chapter5/predictor.py
@@ -5,7 +5,7 @@ import numpy as np
 from tqdm import trange, tqdm
 
 from .env import Enviroment
-from .types import State, StateIndex, Trajectory
+from .types import State, Trajectory
 
 
 class Predictor(metaclass=ABCMeta):

--- a/chapter5/predictor.py
+++ b/chapter5/predictor.py
@@ -16,14 +16,7 @@ class Predictor(metaclass=ABCMeta):
 
     def reset(self):
         shape = [dim.n for dim in self.env.obs_space]
-        self._obs_space_mins = [x.minimum for x in self.env.obs_space.dims]
         self.V = np.zeros(shape=shape, dtype=np.float32)
-
-    def idx_to_state(self, idx: StateIndex) -> State:
-        return tuple(x + _min for x, _min in zip(idx, self._obs_space_mins))
-
-    def state_to_idx(self, state: StateIndex) -> State:
-        return tuple(x - _min for x, _min in zip(state, self._obs_space_mins))
 
     @abstractmethod
     def predict(self) -> None:
@@ -57,6 +50,7 @@ class MonteCarloPredictor(Predictor):
             finished, new_state, reward = self.env.step(action)
             current_state = new_state
         trajectory.add_step(finished, current_state, reward, None)
+        # print(trajectory)
         return trajectory
 
     def predict(
@@ -85,11 +79,10 @@ class MonteCarloPredictor(Predictor):
         for i in range(len(trajectory) - 2, -1, -1):
             G += self.gamma * trajectory[i + 1].reward
             previous_states.pop()
-            s = trajectory[i].state
-            if s not in previous_states:
-                s_idx = self.state_to_idx(s)
-                self.N[s_idx] += 1
-                self.V[s_idx] += alpha * (G - self.V[s_idx]) / self.N[s_idx]
+            state = trajectory[i].state
+            if state not in previous_states:
+                self.N[state] += 1
+                self.V[state] += alpha * (G - self.V[state]) / self.N[state]
 
     def reset(self, init_value: float = 0.0):
         super(MonteCarloPredictor, self).reset()

--- a/chapter5/predictor.py
+++ b/chapter5/predictor.py
@@ -50,7 +50,6 @@ class MonteCarloPredictor(Predictor):
             finished, new_state, reward = self.env.step(action)
             current_state = new_state
         trajectory.add_step(finished, current_state, reward, None)
-        # print(trajectory)
         return trajectory
 
     def predict(

--- a/chapter5/types.py
+++ b/chapter5/types.py
@@ -2,8 +2,6 @@ from typing import List, Tuple, NamedTuple
 
 
 State = Tuple[int, ...]
-StateIndex = Tuple[int, ...]
-StateActionIndex = Tuple[int, ...]
 
 
 class Observation(NamedTuple):

--- a/chapter6/env.py
+++ b/chapter6/env.py
@@ -8,13 +8,13 @@ from chapter5.types import Observation, State
 class RandomWalk(Enviroment):
     def __init__(self, n: int = 5):
         assert n % 2, "n must be odd"
-        self.limit = n // 2
-        self._act_space = DiscreteDim(2, minimum=0)
-        self._obs_space = DiscreteSpace(DiscreteDim(n, minimum=-self.limit))
+        self.n = n
+        self._act_space = DiscreteDim(2)
+        self._obs_space = DiscreteSpace(DiscreteDim(n))
         self.reset()
 
     def reset(self):
-        self.s = 0
+        self.s = self.n // 2 + 1
 
     @property
     def state(self) -> State:
@@ -23,8 +23,8 @@ class RandomWalk(Enviroment):
     def step(self, action: int) -> Observation:
         assert self.act_space.contains(action), "Invalid action"
         self.s += action if action else -1
-        reward = 1 if self.s > self.limit else 0
-        done = np.abs(self.s) > self.limit
+        reward = 1 if self.s >= self.n else 0
+        done = self.s >= self.n or self.s < 0
         return Observation(done, self.state, reward)
 
 
@@ -40,7 +40,7 @@ class WindyGridWorld(Enviroment):
         self.m = m
         self.winds = winds
         self.reward_pos = reward_pos
-        self._act_space = DiscreteDim(4, minimum=0)
+        self._act_space = DiscreteDim(4)
         self._obs_space = DiscreteSpace(DiscreteDim(self.n), DiscreteDim(self.m))
         self.reset()
 
@@ -74,7 +74,7 @@ class CliffGridWorld(Enviroment):
         assert m > 2, f"m ({2}) must be greater than 2"
         self.n = n
         self.m = m
-        self._act_space = DiscreteDim(4, minimum=0)
+        self._act_space = DiscreteDim(4)
         self._obs_space = DiscreteSpace(DiscreteDim(self.n), DiscreteDim(self.m))
         self.reset()
 
@@ -106,7 +106,7 @@ class DoubleState(Enviroment):
     def __init__(self, n: Optional[int] = 10):
         assert n >= 10, "n must be greater than 10"
         self.n = n
-        self._act_space = DiscreteDim(self.n, minimum=0)
+        self._act_space = DiscreteDim(self.n)
         self._obs_space = DiscreteSpace(DiscreteDim(2))
         self._a_legal_actions = [0, 1]
         self._b_legal_actions = list(range(1, n))

--- a/chapter6/predictor.py
+++ b/chapter6/predictor.py
@@ -78,7 +78,7 @@ class TDPredictor(Predictor):
         done: bool,
         reward: float,
     ) -> None:
-        c_s_idx = self.state_to_idx(current_state)
-        n_s_idx = self.state_to_idx(new_state)
-        next_v = 0 if done else self.V[n_s_idx]
-        self.V[c_s_idx] += alpha * (reward + self.gamma * next_v - self.V[c_s_idx])
+        next_v = 0 if done else self.V[new_state]
+        self.V[current_state] += alpha * (
+            reward + self.gamma * next_v - self.V[current_state]
+        )


### PR DESCRIPTION
It deletes the need to use the methods `state_to_idx` and `state_action_to_idx` by restricting the `DiscreteSpace`s to allways start at 0.